### PR TITLE
feat(debug): add cli for heap snapshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 **/.angular
 **/.idea
 **/.env
+**/.pid
 **/dist
 **/cache
 **/tmp

--- a/backend/cli.ts
+++ b/backend/cli.ts
@@ -2,6 +2,7 @@ import "reflect-metadata";
 
 import cli from "app/cli";
 
+import "cli/debug";
 import "cli/environment";
 import "cli/migrations";
 import "cli/modules";

--- a/backend/cli/debug.ts
+++ b/backend/cli/debug.ts
@@ -1,0 +1,15 @@
+import cli, { Command } from "app/cli";
+import { createLogger } from "core-kit/packages/logger";
+import { readFile } from "fs/promises";
+
+const logger = createLogger("debug");
+
+const commands = new Command("debug");
+
+commands.command("server").action(async (name: string) => {
+  const pid = parseInt(await readFile("server.pid", "utf8"));
+  process.kill(pid, "SIGHUP");
+  process.exit();
+});
+
+cli.addCommand(commands);

--- a/backend/packages/debug/index.ts
+++ b/backend/packages/debug/index.ts
@@ -1,0 +1,1 @@
+import "./snapshot";

--- a/backend/packages/debug/snapshot.ts
+++ b/backend/packages/debug/snapshot.ts
@@ -1,0 +1,15 @@
+import { createLogger } from "core-kit/packages/logger";
+import * as os from "os";
+import * as path from "path";
+import * as v8 from "v8";
+
+const logger = createLogger("debug");
+
+process.on("SIGHUP", () => {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const filename = `heap-snapshot-${timestamp}.heapsnapshot`;
+
+  logger.info("Creating snapshot...");
+  const filepath = v8.writeHeapSnapshot(path.join(os.tmpdir(), filename));
+  logger.info(`✅ Done to ${filepath}`);
+});

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -31,9 +31,11 @@ import "./api/users";
 import "./api/utils";
 
 import "./api/deploys";
+import "./packages/debug";
 
 import { ALLOW_SIGNUP, APP_FOOTER, GOOGLE_AUTH, YANDEX_AUTH } from "consts/ui";
 import { ALL_LANGUAGES } from "core-kit/packages/locale";
+import { writeFile } from "fs/promises";
 import { BASE_URL, FRONTEND_ROOT, SITE_URL } from "./consts/core";
 import { NO_CACHE_HEADERS, SCP_HEADERS } from "./consts/http";
 import { AppConfig } from "./models/app-config";
@@ -147,3 +149,5 @@ export const PORT =
 api.listen(PORT, () => {
   logger.debug("Server is running");
 });
+
+await writeFile("server.pid", `${process.pid}`);


### PR DESCRIPTION
As a DevOps Engineer, I want to make heaps snapshot to prevent RAM leaks.

# Approach from Nginx

Nginx uses Unix signals to manage its processes, including reloading configuration, graceful shutdown, and restarting worker processes.

Signal | Effect | Equivalent Command
-- | -- | --
**HUP** | Reload configuration gracefully | nginx -s reload
TERM | Fast shutdown | nginx -s stop
QUIT | Graceful shutdown | nginx -s quit
USR1 | Reopen log files (for log rotation) | nginx -s reopen
WINCH | Gracefully shut down worker processes | (used in upgrades)

You can use **HUP** for:
1. Toggling debug mode
2. Restarting a specific part of the app
3. Triggering a config reload
4. Custom internal events

# Implementation

```ts
process.on("SIGHUP", () => {
  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
  const filename = `heap-snapshot-${timestamp}.heapsnapshot`;

  logger.info("Creating snapshot...");
  const filepath = v8.writeHeapSnapshot(path.join(os.tmpdir(), filename));
  logger.info(`✅ Done to ${filepath}`);
});
```

Then in CLI `npm run cli debug server`

```ts
commands.command("server").action(async (name: string) => {
  const pid = parseInt(await readFile("server.pid", "utf8"));
  process.kill(pid, "SIGHUP");
  process.exit();
});
```